### PR TITLE
Corrections of Japanese language page

### DIFF
--- a/_data/langs/ja.yml
+++ b/_data/langs/ja.yml
@@ -188,7 +188,7 @@ footer:
     reddit: "Reddit"
     steam: "Steam"
     telegram: "Telegram"
-    verge_radio: "Vergeラジオ"
+    verge_radio: "バージ・ラジオ"
     discord: "Verge Discord"
   tweets:
     header: "ツイート"


### PR DESCRIPTION
We corrected  words of Verge official website's japanese page to native Japanese expression. 
Please apply it, if there is no problem.